### PR TITLE
Attempt to restore whitespaces in inline-table

### DIFF
--- a/src/pyproject_fmt/formatter/util.py
+++ b/src/pyproject_fmt/formatter/util.py
@@ -39,20 +39,25 @@ def order_keys(
 ) -> None:
     body = table.value.body
     entries = {i.key: (i, v) for (i, v) in body if isinstance(i, Key)}
-    body.clear()
+    sorted_entries = []
 
     for pin in to_pin or []:  # push pinned to start
         if pin in entries:
-            body.append(entries[pin])
+            sorted_entries.append(entries[pin])
             del entries[pin]
     # append the rest
     if sort_key is None:
-        body.extend(entries.values())
+        sorted_entries.extend(entries.values())
     else:
-        body.extend(v for k, v in sorted(entries.items(), key=sort_key))
+        sorted_entries.extend(v for k, v in sorted(entries.items(), key=sort_key))
 
     if isinstance(table, Table):
-        body.append((None, Whitespace("\n")))  # add trailing newline to separate
+        sorted_entries.append((None, Whitespace("\n")))  # add trailing newline to separate
+
+    # Copy all elements from the normalised table into the existing one
+    table.clear()
+    for key, value in sorted_entries:
+        table.add(key, value)
 
 
 @dataclass

--- a/tests/formatter/test_project.py
+++ b/tests/formatter/test_project.py
@@ -101,7 +101,7 @@ def test_entry_points(fmt: Fmt) -> None:
     """
     expected = """
     [project.entry-points]
-    alpha = {"A.A" = "a",B = "b"}
-    beta = {C = "c",D = "d"}
+    alpha = {"A.A" = "a", B = "b"}
+    beta = {C = "c", D = "d"}
     """
     fmt(fmt_project, start, expected)


### PR DESCRIPTION
This is a (mostly failed) attempt to solve the problem pointed out in:
> This reads badly, can we add a space between `,` for inline tables? 🤔 while we're at it.
_Originally posted by @gaborbernat in https://github.com/tox-dev/pyproject-fmt/pull/12#r816211130_

Although this solution does solve the problem pointed out in the comment, it introduces another one. For example, the following diff is generated by `tests/formatter/test_project.py:107`:

```diff
+
+ [project]

  [project.entry-points]
- alpha = {"A.A" = "a", B = "b"}
+ alpha = { "A.A" = "a", B = "b"}
?          +
- beta = {C = "c", D = "d"}
+ beta = { C = "c", D = "d"}
?         +
```

As shown in the output above, some "ghost" whitespaces are left behind when doing `table.clear()`.
If we replace `table.clear()` with `body.clear()` (or add it as a following statement) we get a `IndexError: list index out of range` exception when adding new elements to the existing table.